### PR TITLE
CI CD pipeline and Terraform upgrade to 1.3.4 and azurerm to 3.31.0

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -42,41 +42,41 @@ variable "subscription_id" {
 #Set variable
 variable "forwarding_rules" {
   description = "Forwarding Rule to Endpoint (cf https://docs.microsoft.com/en-us/azure/data-factory/tutorial-managed-virtual-network-on-premise-sql-server?WT.mc_id=AZ-MVP-5003548&WT.mc_id=AZ-MVP-5003548#creating-forwarding-rule-to-endpoint)."
-  type = any
+  type        = any
   default = {
     "sql-demo1" = {
-      source_port = "1433"
+      source_port         = "1433"
       destination_address = "sql1.dld23.com"
-      destination_port = "1433"
+      destination_port    = "1433"
     }
     "sql-demo2" = {
-      source_port = "1434"
+      source_port         = "1434"
       destination_address = "sql2.dld23.com"
-      destination_port = "1433"
+      destination_port    = "1433"
     }
     "sftp-demo1" = {
-      source_port = "221"
+      source_port         = "221"
       destination_address = "sftp.dld23.com"
-      destination_port = "22"
+      destination_port    = "22"
     }
   }
 }
 
 #Call module
 module "Az-PrivateLinkForNonAzureResources-Demo" {
-  source = "JamesDLD/Az-PrivateLinkForNonAzureResources/azurerm"
-  version = "0.2.0"
+  source   = "JamesDLD/Az-PrivateLinkForNonAzureResources/azurerm"
+  version  = "0.2.0"
   location = "westeurope"
   additional_tags = {
     usage = "demo"
   }
-  prefix = "dlddemo"
-  suffix = "001"
-  resource_group_name = "xxxxxxxxxxxxxx"
-  subnet_id_private_link = "/subscriptions/xxxxxxxxxxxxxx/resourceGroups/xxxxxxxxxxxxxx/providers/Microsoft.Network/virtualNetworks/xxxxxxxxxxxxxx/subnets/xxxxxxxxxxxxxxsub1"
-  subnet_id_load_balancer = "/subscriptions/xxxxxxxxxxxxxx/resourceGroups/xxxxxxxxxxxxxx/providers/Microsoft.Network/virtualNetworks/xxxxxxxxxxxxxx/subnets/xxxxxxxxxxxxxxsub2"
+  prefix                              = "dlddemo"
+  suffix                              = "001"
+  resource_group_name                 = "xxxxxxxxxxxxxx"
+  subnet_id_private_link              = "/subscriptions/xxxxxxxxxxxxxx/resourceGroups/xxxxxxxxxxxxxx/providers/Microsoft.Network/virtualNetworks/xxxxxxxxxxxxxx/subnets/xxxxxxxxxxxxxxsub1"
+  subnet_id_load_balancer             = "/subscriptions/xxxxxxxxxxxxxx/resourceGroups/xxxxxxxxxxxxxx/providers/Microsoft.Network/virtualNetworks/xxxxxxxxxxxxxx/subnets/xxxxxxxxxxxxxxsub2"
   subnet_id_virtual_machine_scale_set = "/subscriptions/xxxxxxxxxxxxxx/resourceGroups/xxxxxxxxxxxxxx/providers/Microsoft.Network/virtualNetworks/xxxxxxxxxxxxxx/subnets/xxxxxxxxxxxxxxsub3"
-  forwarding_rules = var.forwarding_rules
+  forwarding_rules                    = var.forwarding_rules
 }
 
 output "azurerm_lb_id" {
@@ -90,6 +90,5 @@ output "azurerm_linux_virtual_machine_scale_set_id" {
 output "azurerm_private_link_service_id" {
   value = module.Az-PrivateLinkForNonAzureResources-Demo.private_link_service_id
 }
-
 
 ```

--- a/examples/demo-hasicorp-meetup/README.md
+++ b/examples/demo-hasicorp-meetup/README.md
@@ -52,28 +52,28 @@ variable "additional_tags" {
 
 variable "forwarding_rules" {
   description = "Forwarding Rule to Endpoint (cf https://docs.microsoft.com/en-us/azure/data-factory/tutorial-managed-virtual-network-on-premise-sql-server?WT.mc_id=AZ-MVP-5003548&WT.mc_id=AZ-MVP-5003548#creating-forwarding-rule-to-endpoint)."
-  type = any
+  type        = any
   default = {
     "demo-static-website" = {
-      source_port = "443"
+      source_port         = "443"
       destination_address = "demoprivatelinksftp.blob.core.windows.net"
-      destination_port = "443"
+      destination_port    = "443"
     }
     "demo-sftp" = {
-      source_port = "223"
+      source_port         = "223"
       destination_address = "demoprivatelinksftp.blob.core.windows.net"
-      destination_port = "22"
+      destination_port    = "22"
     }
   }
 }
 
 variable "virtual_network" {
   default = {
-    name = "hashicorp-privatelink-npd-vnet4"
+    name          = "hashicorp-privatelink-npd-vnet4"
     address_space = ["10.0.128.0/24", "198.18.2.0/24"]
     subnets = {
       privatelink = {
-        address_prefixes = ["10.0.128.0/28"]
+        address_prefixes                              = ["10.0.128.0/28"]
         private_link_service_network_policies_enabled = false
       }
 
@@ -98,107 +98,107 @@ data "azurerm_resource_group" "rg" {
 }
 
 resource "azurerm_virtual_network" "Demo" {
-  name = var.virtual_network.name
-  location = data.azurerm_resource_group.rg.location
+  name                = var.virtual_network.name
+  location            = data.azurerm_resource_group.rg.location
   resource_group_name = data.azurerm_resource_group.rg.name
-  address_space = var.virtual_network.address_space
-  tags = data.azurerm_resource_group.rg.tags
+  address_space       = var.virtual_network.address_space
+  tags                = data.azurerm_resource_group.rg.tags
 }
 
 resource "azurerm_subnet" "Demo" {
-  for_each = var.virtual_network.subnets
-  name = each.key
-  resource_group_name = data.azurerm_resource_group.rg.name
-  virtual_network_name = azurerm_virtual_network.Demo.name
-  address_prefixes = each.value.address_prefixes
+  for_each                                      = var.virtual_network.subnets
+  name                                          = each.key
+  resource_group_name                           = data.azurerm_resource_group.rg.name
+  virtual_network_name                          = azurerm_virtual_network.Demo.name
+  address_prefixes                              = each.value.address_prefixes
   private_link_service_network_policies_enabled = lookup(each.value, "private_link_service_network_policies_enabled", null)
   #(Optional) Enable or Disable network policies for the private link service on the subnet. Default valule is false. Conflicts with enforce_private_link_endpoint_network_policies.
 }
 
 #Call module
 module "Az-PrivateLinkForNonAzureResources-Demo" {
-  source = "JamesDLD/Az-PrivateLinkForNonAzureResources/azurerm"
-  version = "0.2.0"
-  location = data.azurerm_resource_group.rg.location
-  additional_tags = var.additional_tags
-  prefix = "demo"
-  suffix = "1"
-  resource_group_name = data.azurerm_resource_group.rg.name
-  subnet_id_private_link = azurerm_subnet.Demo["privatelink"].id
-  subnet_id_load_balancer = azurerm_subnet.Demo["loadbalancer"].id
+  source                              = "JamesDLD/Az-PrivateLinkForNonAzureResources/azurerm"
+  version                             = "0.2.0"
+  location                            = data.azurerm_resource_group.rg.location
+  additional_tags                     = var.additional_tags
+  prefix                              = "demo"
+  suffix                              = "1"
+  resource_group_name                 = data.azurerm_resource_group.rg.name
+  subnet_id_private_link              = azurerm_subnet.Demo["privatelink"].id
+  subnet_id_load_balancer             = azurerm_subnet.Demo["loadbalancer"].id
   subnet_id_virtual_machine_scale_set = azurerm_subnet.Demo["compute"].id
-  forwarding_rules = var.forwarding_rules
+  forwarding_rules                    = var.forwarding_rules
 }
 
 #Azure Bastion
 resource "azurerm_public_ip" "Demo-bastion" {
-  name = "demo-azure-bastion-pip"
-  location = data.azurerm_resource_group.rg.location
+  name                = "demo-azure-bastion-pip"
+  location            = data.azurerm_resource_group.rg.location
   resource_group_name = data.azurerm_resource_group.rg.name
-  allocation_method = "Static"
-  sku = "Standard"
+  allocation_method   = "Static"
+  sku                 = "Standard"
 }
 
 resource "azurerm_bastion_host" "Demo" {
-  name = "demo-azure-bastion"
-  location = data.azurerm_resource_group.rg.location
-  resource_group_name = data.azurerm_resource_group.rg.name
-  copy_paste_enabled = true
-  file_copy_enabled = true
+  name                   = "demo-azure-bastion"
+  location               = data.azurerm_resource_group.rg.location
+  resource_group_name    = data.azurerm_resource_group.rg.name
+  copy_paste_enabled     = true
+  file_copy_enabled      = true
   shareable_link_enabled = true
-  sku = "Standard"
+  sku                    = "Standard"
 
   ip_configuration {
-    name = "configuration"
-    subnet_id = azurerm_subnet.Demo["AzureBastionSubnet"].id
+    name                 = "configuration"
+    subnet_id            = azurerm_subnet.Demo["AzureBastionSubnet"].id
     public_ip_address_id = azurerm_public_ip.Demo-bastion.id
   }
 }
 
 #NAT Gateway
 resource "azurerm_public_ip" "Demo-nat-gateway" {
-  name = "demo-nat-gateway-pip"
-  location = data.azurerm_resource_group.rg.location
+  name                = "demo-nat-gateway-pip"
+  location            = data.azurerm_resource_group.rg.location
   resource_group_name = data.azurerm_resource_group.rg.name
-  allocation_method = "Static"
-  sku = "Standard"
-  zones = ["1"]
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  zones               = ["1"]
 }
 
 resource "azurerm_nat_gateway" "Demo" {
-  name = "demo-nat-gateway"
-  location = data.azurerm_resource_group.rg.location
-  resource_group_name = data.azurerm_resource_group.rg.name
-  sku_name = "Standard"
+  name                    = "demo-nat-gateway"
+  location                = data.azurerm_resource_group.rg.location
+  resource_group_name     = data.azurerm_resource_group.rg.name
+  sku_name                = "Standard"
   idle_timeout_in_minutes = 10
-  zones = ["1"]
+  zones                   = ["1"]
 }
 
 resource "azurerm_nat_gateway_public_ip_association" "Demo" {
-  nat_gateway_id = azurerm_nat_gateway.Demo.id
+  nat_gateway_id       = azurerm_nat_gateway.Demo.id
   public_ip_address_id = azurerm_public_ip.Demo-nat-gateway.id
 }
 
 resource "azurerm_subnet_nat_gateway_association" "Demo-Subnet-compute" {
-  subnet_id = azurerm_subnet.Demo["compute"].id
+  subnet_id      = azurerm_subnet.Demo["compute"].id
   nat_gateway_id = azurerm_nat_gateway.Demo.id
 }
 
 # SFTP
 resource "azurerm_storage_account" "Demo" {
-  name = "demoprivatelinksftp"
-  resource_group_name = "module-private-link-noprd-rg1"
-  location = data.azurerm_resource_group.rg.location
-  account_tier = "Standard"
-  account_replication_type = "LRS"
-  is_hns_enabled = true
+  name                            = "demoprivatelinksftp"
+  resource_group_name             = "module-private-link-noprd-rg1"
+  location                        = data.azurerm_resource_group.rg.location
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  is_hns_enabled                  = true
   allow_nested_items_to_be_public = false
 }
 
 # Workaround until azurerm_storage_account supports isSftpEnabled property
 # see https://github.com/hashicorp/terraform-provider-azurerm/issues/14736
 resource "azapi_update_resource" "Demo-enable-sftp" {
-  type = "Microsoft.Storage/storageAccounts@2021-09-01"
+  type        = "Microsoft.Storage/storageAccounts@2021-09-01"
   resource_id = azurerm_storage_account.Demo.id
 
   body = jsonencode({

--- a/examples/demo-hasicorp-meetup/main.tf
+++ b/examples/demo-hasicorp-meetup/main.tf
@@ -91,8 +91,8 @@ resource "azurerm_subnet" "Demo" {
 
 #Call module
 module "Az-PrivateLinkForNonAzureResources-Demo" {
-  source   = "JamesDLD/Az-PrivateLinkForNonAzureResources/azurerm"
-  version  = "0.2.0"
+  source                              = "JamesDLD/Az-PrivateLinkForNonAzureResources/azurerm"
+  version                             = "0.2.0"
   location                            = data.azurerm_resource_group.rg.location
   additional_tags                     = var.additional_tags
   prefix                              = "demo"


### PR DESCRIPTION
## 0.2.0 (November 14, 2022)

FEATURES:
* Upgrade to Terraform 1.3.4 and above.
* Upgrade to AzureRm provider 3.31.0 and above.

ENHANCEMENTS:
* Implement a CI CD pipeline.
* Delete the deprecated version constraint in the azurerm provider.
* Code formatting with IntelliJ and `terraform fmt -recursive`.
* Add a change log file.
* Share the code example used during the Demo used during the [[HUG] Meetup Paris #17 - Novembre 2022](https://www.meetup.com/fr-FR/Hashicorp-User-Group-Paris/events/289541806/?utm_medium=email&utm_source=braze_canvas&utm_campaign=mmrk_alleng_event_announcement_prod_v7_fr&utm_term=promo&utm_content=lp_meetup).

BUG FIXES:
* Replace the deprecated block `scale_in_policy` by `scale_in` on the resource `azurerm_linux_virtual_machine_scale_set`.
* Delete the deprecated option `resource_group_name`on the resources `azurerm_lb_backend_address_pool`, `azurerm_lb_probe` and `azurerm_lb_rule`.
